### PR TITLE
support passing auth by env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This project serves up falco rule sets over an HTTP(S) web service. It currently
 This service concatenates rule sets based on the ones requested. 
 
 # Authentication
-User config is defined in a file named: `/secrets/auth.yml`. This file should be mounted by GCP secrets, a docker volume, or similar method. A sample user config file is in `test/auth.yml`. It is a yaml file that has a map of `token`->`username`
+User config is defined in a file named: `/secrets/auth.yml` or as yaml passed via the `FCS_AUTH` environmental variable. If using a file it should be mounted by GCP secrets, a docker volume, or similar method. A sample user config file is in `test/auth.yml`. It is a yaml file that has a map of `token`->`username`
 
 Requests should be authenticated by putting the user token in an `X-Auth-Token` header on the request. 
 
 Requests may also use basic authentication.
 
-The health check (`/`) is always allowed without authentication
+The health check (`/`) is always allowed without authentication.
 
 # Endpoints
 

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ type RulesetRequest struct {
 
 func configLogger() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-	_, dob := os.LookupEnv("FAM_DEBUG")
+	_, dob := os.LookupEnv("FCS_DEBUG")
 	if dob {
 		log.Info().Msg("Log level set to DEBUG")
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
@@ -104,8 +104,9 @@ func main() {
 	r.HandleFunc("/ruleset", GetRules).Methods("GET")
 	r.HandleFunc("/sum", GetSum).Methods("GET")
 	//setup auth middleware
-	amw := authenticationMiddleware{make(map[string]string)}
-	amw.Populate()
+	// if the FCS_AUTH env var is set then use that,
+	// otherwise we're going to read
+	amw := NewAuthMiddleware()
 	r.Use(amw.Middleware)
 	// start the server
 	err := http.ListenAndServe(port, r)

--- a/rules_test.go
+++ b/rules_test.go
@@ -45,7 +45,7 @@ func TestHash(t *testing.T) {
 	}
 	h1sum := h1.Sum(nil)
 	// call get sum from main
-	rPath := fmt.Sprintf("/sum?rulesets=sample")
+	rPath := "/sum?rulesets=sample"
 	req, err := http.NewRequest("GET", rPath, nil)
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(GetSum)


### PR DESCRIPTION
This allows for setting authentication via environmental variable if not using a secrets file. Env var is treated as an override for the secrets file.